### PR TITLE
Dev/refactoring

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -1,6 +1,7 @@
 # coding: UTF-8
 
 import asyncio
+import functools
 import json
 import logging
 import time
@@ -12,7 +13,6 @@ from signal import SIGCONT, SIGSTOP
 from typing import Any, Callable, Generator, Optional
 
 import aiofiles
-import functools
 import pika
 import psutil
 import rdtsc

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -117,8 +117,8 @@ class Benchmark:
         logger.info(f'The benchmark has started. pid : {self._bench_driver.pid}')
 
         self._pause_bench()
-        bench_path = str(self._bench_driver.name)+'_'+str(self._bench_driver.pid)
-        self._res_path = self._res_path / bench_path
+
+        self._res_path = self._res_path / f'{self._bench_driver.name}_{self._bench_driver.pid}'
 
         # create a resource group and register this benchmark to the group
         proc = await asyncio.create_subprocess_exec('sudo', 'mkdir', str(self._res_path))

--- a/benchmark/driver/base_driver.py
+++ b/benchmark/driver/base_driver.py
@@ -74,7 +74,7 @@ class BenchDriver(metaclass=ABCMeta):
     @staticmethod
     def get_bench_home(bench_name: str) -> str:
         from benchmark_launcher import GLOBAL_CFG_PATH
-        with open(GLOBAL_CFG_PATH) as fp:
+        with GLOBAL_CFG_PATH.open() as fp:
             return json.load(fp)['benchmark'][bench_name]
 
     @property

--- a/benchmark/driver/base_driver.py
+++ b/benchmark/driver/base_driver.py
@@ -1,14 +1,14 @@
 # coding: UTF-8
 
 import asyncio
+import functools
 import json
+from abc import ABCMeta, abstractmethod
 from itertools import chain
 from signal import SIGCONT, SIGSTOP
 from typing import Any, Callable, Iterable, Optional, Set, Type
 
-import functools
 import psutil
-from abc import ABCMeta, abstractmethod
 
 
 class BenchDriver(metaclass=ABCMeta):

--- a/benchmark_launcher.py
+++ b/benchmark_launcher.py
@@ -141,14 +141,14 @@ def power_monitor(work_space: Path):
     ret: List[Dict[str, Union[str, int, Dict[str, int]]]] = list()
 
     for socket_path, (prev_socket_power, socket) in monitors.items():
-        with open(socket_path / 'name') as name_fp, open(socket_path / _ENERGY_FILE_NAME) as power_fp:
+        with (socket_path / 'name').open() as name_fp, (socket_path / _ENERGY_FILE_NAME).open() as power_fp:
             sub_name = name_fp.readline().strip()
             after = int(power_fp.readline())
 
         if after > prev_socket_power:
             diff = after - prev_socket_power
         else:
-            with open(socket_path / _MAX_ENERGY_VALUE_FILE_NAME) as fp:
+            with (socket_path / _MAX_ENERGY_VALUE_FILE_NAME).open() as fp:
                 max_value = int(fp.readline())
                 diff = max_value - prev_socket_power + after
 
@@ -159,14 +159,14 @@ def power_monitor(work_space: Path):
         }
 
         for path, before in socket.items():
-            with open(path / _ENERGY_FILE_NAME) as energy_fp, open(path / 'name') as name_fp:
+            with (path / _ENERGY_FILE_NAME).open() as energy_fp, (path / 'name').open() as name_fp:
                 after = int(energy_fp.readline())
                 name = name_fp.readline().strip()
 
                 if after > prev_socket_power:
                     diff = after - before
                 else:
-                    with open(path / _MAX_ENERGY_VALUE_FILE_NAME) as fp:
+                    with (path / _MAX_ENERGY_VALUE_FILE_NAME).open() as fp:
                         max_value = int(fp.readline())
                         diff = max_value - before + after
 
@@ -176,7 +176,7 @@ def power_monitor(work_space: Path):
 
     result_file = work_space / 'result.json'
     if result_file.exists():
-        with open(result_file, mode='r+') as fp:
+        with result_file.open('r+') as fp:
             try:
                 original = json.load(fp)
                 original['power'] = ret
@@ -189,7 +189,7 @@ def power_monitor(work_space: Path):
                 fp.truncate()
                 json.dump({'power': ret}, fp, indent=4)
     else:
-        with open(result_file, mode='w') as fp:
+        with result_file.open('w') as fp:
             json.dump({'power': ret}, fp, indent=4)
 
 
@@ -197,24 +197,24 @@ def power_monitor(work_space: Path):
 def hyper_threading_guard(loop: asyncio.AbstractEventLoop, ht_flag):
     async def _gather_online_core(online_file: Path, core_id: int):
         if online_file.is_file():
-            async with aiofiles.open(online_file) as fp:
-                line = await fp.readline()
+            async with aiofiles.open(online_file) as afp:
+                line = await afp.readline()
                 if line.strip() == '1':
                     return core_id
 
     jobs: List[Coroutine] = []
 
-    core_id = 1
+    cur_core_id = 1
     while True:
-        path = Path(f'/sys/devices/system/cpu/cpu{core_id}')
+        path = Path(f'/sys/devices/system/cpu/cpu{cur_core_id}')
 
         if not path.is_dir():
             break
 
         else:
-            jobs.append(_gather_online_core(path / 'online', core_id))
+            jobs.append(_gather_online_core(path / 'online', cur_core_id))
 
-        core_id += 1
+        cur_core_id += 1
 
     online_core: Set[int] = set(filter(None.__ne__, loop.run_until_complete(asyncio.gather(*jobs))))
 
@@ -223,8 +223,8 @@ def hyper_threading_guard(loop: asyncio.AbstractEventLoop, ht_flag):
 
         logical_cores: Set[int] = set()
 
-        for core_id in online_core | {0}:
-            with open(f'/sys/devices/system/cpu/cpu{core_id}/topology/thread_siblings_list') as fp:
+        for cur_core_id in online_core | {0}:
+            with open(f'/sys/devices/system/cpu/cpu{cur_core_id}/topology/thread_siblings_list') as fp:
                 for core in fp.readline().strip().split(',')[1:]:
                     logical_cores.add(int(core))
 
@@ -240,7 +240,7 @@ def hyper_threading_guard(loop: asyncio.AbstractEventLoop, ht_flag):
     subprocess.run(('sudo', 'tee', *files_to_write), input="1", encoding='UTF-8', stdout=subprocess.DEVNULL)
 
 
-GLOBAL_CFG_PATH = Path(__file__).resolve().parent / 'config.json'
+GLOBAL_CFG_PATH: Path = Path(__file__).resolve().parent / 'config.json'
 
 
 def launch(loop: asyncio.AbstractEventLoop, workspace: Path, print_log: bool, print_metric_log: bool, verbose: bool):
@@ -253,8 +253,8 @@ def launch(loop: asyncio.AbstractEventLoop, workspace: Path, print_log: bool, pr
         print(f'{config_file.resolve()} is not exist.', file=sys.stderr)
         return False
 
-    with open(config_file) as local_config_fp, \
-            open(GLOBAL_CFG_PATH) as global_config_fp:
+    with config_file.open() as local_config_fp, \
+            GLOBAL_CFG_PATH.open() as global_config_fp:
         local_cfg_source: Dict[str, Any] = json.load(local_config_fp)
         global_cfg_source: Dict[str, Any] = json.load(global_config_fp)
 
@@ -285,7 +285,7 @@ def launch(loop: asyncio.AbstractEventLoop, workspace: Path, print_log: bool, pr
         a_bench = task_map[a_task]
 
         if result_file.exists():
-            with open(result_file, mode='r+') as fp:
+            with result_file.open('r+') as fp:
                 try:
                     original: Dict[str, Any] = json.load(fp)
 
@@ -302,7 +302,7 @@ def launch(loop: asyncio.AbstractEventLoop, workspace: Path, print_log: bool, pr
                     fp.truncate()
                     json.dump({'runtime': {a_bench.identifier: a_bench.runtime}}, fp, indent=4)
         else:
-            with open(result_file, mode='w') as fp:
+            with result_file.open('w') as fp:
                 json.dump({'runtime': {a_bench.identifier: a_bench.runtime}}, fp, indent=4)
 
         a_task.remove_done_callback(store_runtime)

--- a/post_scripts/avg_csv.py
+++ b/post_scripts/avg_csv.py
@@ -22,7 +22,7 @@ def run(workspace: Path, global_cfg_path: Path):
 
     categories: OrderedSet = reduce(lambda a, b: a | b, map(lambda x: OrderedSet(x.metrics.keys()), results))
     fields = tuple(map(lambda x: x.name, results))
-    with open(output_path / 'avg.csv', mode='w') as fp:
+    with (output_path / 'avg.csv').open('w') as fp:
         csv_writer = csv.DictWriter(fp, ('category', *fields))
         csv_writer.writeheader()
 

--- a/post_scripts/avg_csv.py
+++ b/post_scripts/avg_csv.py
@@ -3,11 +3,11 @@
 
 import csv
 from collections import OrderedDict
+from functools import reduce
 from pathlib import Path
 from statistics import mean
 from typing import List
 
-from functools import reduce
 from orderedset import OrderedSet
 
 from post_scripts.tools import WorkloadResult, read_result

--- a/post_scripts/template.py
+++ b/post_scripts/template.py
@@ -21,5 +21,5 @@ def run(workspace: Path, global_cfg_path: Path):
     if not output_path.exists():
         output_path.mkdir(parents=True)
 
-    with open(output_path / 'avg.csv', mode='w') as fp:
+    with (output_path / 'avg.csv').open('w') as fp:
         fp.flush()

--- a/post_scripts/tools.py
+++ b/post_scripts/tools.py
@@ -39,7 +39,7 @@ def read_result(workspace: Path) -> List[WorkloadResult]:
     if not result_file.is_file() or not metric_path.is_dir():
         raise ValueError('run benchmark_launcher.py first!')
 
-    with open(result_file) as result_fp:
+    with result_file.open() as result_fp:
         result: Dict[str, Any] = json.load(result_fp)
 
     ret: List[WorkloadResult] = list()
@@ -47,7 +47,7 @@ def read_result(workspace: Path) -> List[WorkloadResult]:
     for workload_name, runtime in result['runtime'].items():  # type: str, float
         metric_map = OrderedDict()
 
-        with open(metric_path / f'{workload_name}.csv') as metric_fp:
+        with (metric_path / f'{workload_name}.csv').open() as metric_fp:
             reader = csv.DictReader(metric_fp)
 
             for field in reader.fieldnames:
@@ -69,8 +69,8 @@ def read_config(workspace: Path, global_cfg_path: Path) -> \
     if not local_cfg_path.is_file() or not global_cfg_path.is_file():
         raise ValueError('run benchmark_launcher.py first!')
 
-    with open(local_cfg_path) as local_fp, \
-            open(global_cfg_path) as global_fp:
+    with local_cfg_path.open() as local_fp, \
+            global_cfg_path.open() as global_fp:
         local_cfg: Dict[str, Any] = json.load(local_fp)
         global_cfg: Dict[str, Any] = json.load(global_fp)
 

--- a/post_scripts/validate_perf.py
+++ b/post_scripts/validate_perf.py
@@ -20,8 +20,8 @@ def run(workspace: Path, global_cfg_path: Path):
             print(f'{result.name} has 0 llc_occupancy value!', file=sys.stderr)
 
             if not error_file.exists():
-                with open(error_file, mode='w') as fp:
+                with error_file.open('w') as fp:
                     fp.write(result.name)
             else:
-                with open(error_file, mode='a') as fp:
+                with error_file.open('a') as fp:
                     fp.write(result.name)


### PR DESCRIPTION
기존에 코드에 쓰이던 `open(Path)`는 `open(path: Union[str, Pathlike, int, bytes])`에 호환되지 않는 API사용이기 때문에, `Path.open()`으로 수정함