### PR TITLE
modularize resctrl

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from signal import SIGCONT, SIGSTOP
 from typing import Any, Callable, Generator, Optional
 
-import aiofiles
 import pika
 import psutil
 import rdtsc
@@ -83,9 +82,6 @@ class Benchmark:
 
         self._log_path: Path = log_parent / f'{identifier}.log'
 
-        # resource group for this benchmark
-        self._res_path = Path('/sys/fs/resctrl')
-
         # setup for loggers
 
         logger = logging.getLogger(self._identifier)
@@ -121,64 +117,6 @@ class Benchmark:
 
         self._pause_bench()
 
-        self._res_path = self._res_path / f'{self._bench_driver.name}_{self._bench_driver.pid}'
-
-        # create a resource group and register this benchmark to the group
-        proc = await asyncio.create_subprocess_exec('sudo', 'mkdir', str(self._res_path))
-        await proc.wait()
-
-        for tid in self._bench_driver.all_child_tid():
-            proc = await asyncio.create_subprocess_exec('sudo', 'tee', str(self._res_path / 'tasks'),
-                                                        stdin=asyncio.subprocess.PIPE,
-                                                        stdout=asyncio.subprocess.DEVNULL)
-            await proc.communicate(str(tid).encode())
-
-    async def _read_llc_occupancy(self):
-        tot_llc = 0
-
-        # sum all llc_occupancy monitors
-        for mon in (self._res_path / 'mon_data').iterdir():
-            llc_monitor_path = mon / 'llc_occupancy'
-
-            if llc_monitor_path.is_file():
-                async with aiofiles.open(llc_monitor_path) as fp:
-                    line: str = await fp.readline()
-                    tot_llc += int(line)
-
-        return tot_llc
-
-    async def _read_local_mem(self):
-        tot_mem = 0
-
-        # sum all local_mem
-        for mon in (self._res_path / 'mon_data').iterdir():
-            local_mem_path = mon / 'mbm_local_bytes'
-
-            if local_mem_path.is_file():
-                async with aiofiles.open(str(local_mem_path)) as afp:
-                    line: str = await afp.readline()
-                    tot_mem += int(line)
-
-        return tot_mem
-
-    async def _read_total_mem(self):
-        tot_mem = 0
-
-        # sum all total_mem
-        for mon in (self._res_path / 'mon_data').iterdir():
-            total_mem_path = mon / 'mbm_total_bytes'
-
-            if total_mem_path.is_file():
-                async with aiofiles.open(str(total_mem_path)) as afp:
-                    line: str = await afp.readline()
-                    tot_mem += int(line)
-
-        return tot_mem
-
-    async def _remove_res_dir(self):
-        proc = await asyncio.create_subprocess_exec('sudo', 'rmdir', str(self._res_path))
-        await proc.wait()
-
     @_Decorators.ensure_running
     async def monitor(self, print_metric_log: bool = False):
         logger = logging.getLogger(self._identifier)
@@ -213,8 +151,7 @@ class Benchmark:
             num_of_events = len(self._perf_config.events)
 
             prev_tsc = rdtsc.get_cycles()
-            prev_local_mem = await self._read_local_mem()
-            prev_total_mem = await self._read_total_mem()
+            _, prev_local_mem, prev_total_mem = await self._bench_driver.read_resctrl()
             while self._bench_driver.is_running and self._perf.returncode is None:
                 record = []
                 ignore_flag = False
@@ -236,19 +173,17 @@ class Benchmark:
                 record.append(str(tmp - prev_tsc))
                 prev_tsc = tmp
 
-                record.append(str(await self._read_llc_occupancy()))
+                llc_occupancy, local_mem, total_mem = await self._bench_driver.read_resctrl()
+                record.append(str(llc_occupancy))
 
-                tmp = await self._read_local_mem()
-                cur_local_mem = tmp - prev_local_mem
+                cur_local_mem = local_mem - prev_local_mem
                 record.append(str(cur_local_mem))
-                prev_local_mem = tmp
+                prev_local_mem = local_mem
 
-                tmp = await self._read_total_mem()
-                record.append(str(max(tmp - prev_total_mem - cur_local_mem, 0)))
-                prev_total_mem = tmp
+                record.append(str(max(total_mem - prev_total_mem - cur_local_mem, 0)))
+                prev_total_mem = total_mem
 
                 if not ignore_flag:
-                    # print(f'{self._identifier} : {record}')
                     metric_logger.info(','.join(record))
 
             logger.info('end of monitoring loop')
@@ -267,7 +202,6 @@ class Benchmark:
                 pass
 
             await self._bench_driver.cleanup()
-            await self._remove_res_dir()
             logger.info('The benchmark is ended.')
             self._remove_logger_handlers()
             self._end_time = time.time()

--- a/benchmark/driver/base_driver.py
+++ b/benchmark/driver/base_driver.py
@@ -143,16 +143,24 @@ class BenchDriver(metaclass=ABCMeta):
 
         await self._cgroup.create_group()
         await self._cgroup.assign_cpus(self._binding_cores)
-        await self._cgroup.assign_mems(await self.__get_effective_mem_modes())
+        mem_sockets = await self.__get_effective_mem_modes()
+        await self._cgroup.assign_mems(mem_sockets)
 
         self._async_proc = await self._launch_bench()
         self._async_proc_info = psutil.Process(self._async_proc.pid)
+
+        nodes = await NumaTopology.get_node_topo()
+        # FIXME: hard coded
+        masks = ['1'] * (max(nodes) + 1)
+        for socket_id in convert_to_set(mem_sockets):
+            masks[socket_id] = ResCtrl.MAX_MASK
 
         while True:
             self._bench_proc_info = self._find_bench_proc()
             if self._bench_proc_info is not None:
                 await self._rename_group(f'{self._name}_{self._bench_proc_info.pid}')
                 await self._resctrl_group.create_group()
+                await self._resctrl_group.assign_llc(*masks)
                 await self._resctrl_group.add_tasks(self.all_child_tid())
                 return
             await asyncio.sleep(0.1)

--- a/benchmark/utils/numa_topology.py
+++ b/benchmark/utils/numa_topology.py
@@ -12,7 +12,7 @@ class NumaTopology:
     BASE_PATH: Path = Path('/sys/devices/system/node')
 
     @staticmethod
-    async def _get_node_topo() -> Set[int]:
+    async def get_node_topo() -> Set[int]:
         online_path: Path = NumaTopology.BASE_PATH / 'online'
 
         async with aiofiles.open(online_path) as fp:
@@ -35,20 +35,20 @@ class NumaTopology:
         return cpu_topo
 
     @staticmethod
-    async def _get_mem_topo() -> Set[int]:
+    async def get_mem_topo() -> Set[int]:
         has_memory_path = NumaTopology.BASE_PATH / 'has_memory'
 
         async with aiofiles.open(has_memory_path) as fp:
             line: str = await fp.readline()
             mem_topo = convert_to_set(line)
 
-            # TODO: mem_topo can be enhanced by using real numa memory access latency
+            # TODO: get_mem_topo can be enhanced by using real numa memory access latency
 
         return mem_topo
 
     @staticmethod
     async def get_numa_info() -> Tuple[Dict[int, Set[int]], Set[int]]:
-        node_list = await NumaTopology._get_node_topo()
+        node_list = await NumaTopology.get_node_topo()
         cpu_topo = await NumaTopology._get_cpu_topo(node_list)
-        mem_topo = await NumaTopology._get_mem_topo()
+        mem_topo = await NumaTopology.get_mem_topo()
         return cpu_topo, mem_topo

--- a/benchmark/utils/resctrl.py
+++ b/benchmark/utils/resctrl.py
@@ -1,0 +1,71 @@
+# coding: UTF-8
+
+import asyncio
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+import aiofiles
+from aiofiles.base import AiofilesContextManager
+
+
+class ResCtrl:
+    MOUNT_POINT = Path('/sys/fs/resctrl')
+
+    def __init__(self) -> None:
+        self._group_name: str = str()
+        self._group_path: Path = ResCtrl.MOUNT_POINT
+
+        self._monitors: Dict[str, List[AiofilesContextManager]] = \
+            dict(llc_occupancy=list(), mbm_local_bytes=list(), mbm_total_bytes=list())
+
+    @property
+    def group_name(self):
+        return self._group_name
+
+    @group_name.setter
+    def group_name(self, new_name):
+        self._group_name = new_name
+        self._group_path: Path = ResCtrl.MOUNT_POINT / new_name
+
+    async def create_group(self) -> None:
+        proc = await asyncio.create_subprocess_exec('sudo', 'mkdir', '-p', str(self._group_path))
+        await proc.communicate()
+
+        for mon in (self._group_path / 'mon_data').iterdir():
+            llc_monitor_path = mon / 'llc_occupancy'
+            local_mem_path = mon / 'mbm_local_bytes'
+            total_mem_path = mon / 'mbm_total_bytes'
+
+            self._monitors['llc_occupancy'].append(await aiofiles.open(llc_monitor_path))
+            self._monitors['mbm_local_bytes'].append(await aiofiles.open(local_mem_path))
+            self._monitors['mbm_total_bytes'].append(await aiofiles.open(total_mem_path))
+
+    async def add_tasks(self, pids: Iterable[int]) -> None:
+        for pid in pids:
+            proc = await asyncio.create_subprocess_exec('sudo', 'tee', str(self._group_path / 'tasks'),
+                                                        stdin=asyncio.subprocess.PIPE,
+                                                        stdout=asyncio.subprocess.DEVNULL)
+            await proc.communicate(str(pid).encode())
+
+    async def read(self) -> Tuple[int, int, int]:
+        ret = list()
+
+        for mons in self._monitors.values():
+            s = 0
+
+            for mon in mons:
+                await mon.seek(0)
+                line = await mon.readline()
+                s += int(line)
+
+            ret.append(s)
+
+        return tuple(ret)
+
+    async def delete(self) -> None:
+        for mon_list in self._monitors.values():
+            for mon in mon_list:
+                await mon.close()
+
+        proc = await asyncio.create_subprocess_exec('sudo', 'rmdir', str(self._group_path))
+        await proc.communicate()


### PR DESCRIPTION
- `resctrl` 관리하는 class를 `utils` 모듈안에 구현함

## 설명
- `resctrl`의 그룹 하나를 `ResCtrl`객체로 나타냄
- `<생성한 객체>.assign_llc()`등으로 해당 객체가 속한 그룹을 제어

## 기타
- `ResCtrl.assign_llc()`를 구현해서 #8 를 해결할 때 쓰일 수 있음
- dcslab-snu/iso-sched#16 에서 말한 Linux 4.15.13의 `resctrl`버그 해결을 위해 default 값 강제하도록 수정